### PR TITLE
Add packaging with setup.cfg and PBR

### DIFF
--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -1,17 +1,9 @@
 '''
 The :mod:`fasttrees` module includes the fast-and-frugal tree classifier.
 '''
-from importlib.metadata import distribution
+from pbr.version import VersionInfo
 
-
-fasttrees_metadata = dict(distribution('fasttrees').metadata)
-
-__version__ = fasttrees_metadata['Version']
-__description__ = fasttrees_metadata['Summary']
-__license__ = fasttrees_metadata['License']
-
-__author__ = fasttrees_metadata['Author']
-__author_email__ = fasttrees_metadata['Author-email']
+__version__ = VersionInfo('fasttrees').release_string()
 
 
 

--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -1,10 +1,10 @@
 '''
 The :mod:`fasttrees` module includes the fast-and-frugal tree classifier.
 '''
-from importlib import metadata
+from importlib.metadata import distribution
 
 
-fasttrees_metadata = dict(metadata.metadata('fasttrees'))
+fasttrees_metadata = dict(distribution('fasttrees').metadata)
 
 __version__ = fasttrees_metadata['Version']
 __description__ = fasttrees_metadata['Summary']

--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -3,6 +3,7 @@ The :mod:`fasttrees` module includes the fast-and-frugal tree classifier.
 '''
 from pbr.version import VersionInfo
 
+
 __version__ = VersionInfo('fasttrees').release_string()
 
 

--- a/fasttrees/__init__.py
+++ b/fasttrees/__init__.py
@@ -1,14 +1,18 @@
 '''
 The :mod:`fasttrees` module includes the fast-and-frugal tree classifier.
 '''
+from importlib import metadata
 
 
-__description__ = "A fast and frugal tree classifier for sklearn"
-__author__ = "Dominic Zijlstra, Stefan Bachhofner"
+fasttrees_metadata = dict(metadata.metadata('fasttrees'))
 
-__license__ = "MIT"
-__version__ = "1.3.1"
-__author_email__ = "dominiczijlstra@gmail.com, bachhofner.dev@gmail.com"
+__version__ = fasttrees_metadata['Version']
+__description__ = fasttrees_metadata['Summary']
+__license__ = fasttrees_metadata['License']
+
+__author__ = fasttrees_metadata['Author']
+__author_email__ = fasttrees_metadata['Author-email']
+
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas<=0.25.3
 scikit-learn<=0.23.2
 pytest<=7.4.0
 pytest-cov<=4.1.0
+pbr==6.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,43 @@
 [metadata]
+name = fasttrees
 version = 1.3.1
+license = MIT
+
 author = Dominic Zijlstra, Stefan Bachhofner
 author_email = dominiczijlstra@gmail.com, bachhofner.dev@gmail.com
+
 description = A fast and frugal tree classifier for sklearn
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+url = https://github.com/fasttrees/fasttrees
+
+project_urls =
+        Documentation = https://fasttrees.github.io/fasttrees
+        Source Code = https://github.com/fasttrees/fasttrees
+        Tracker = https://github.com/fasttrees/fasttrees/issues
+
+
+[options]
+packages = find: fasttrees
+
+python_requires = >=3.8
+
+install_requires =
+    numpy<=1.19.5,
+    pandas<=0.25.3,
+    scikit-learn<=0.23.2
+
+classifiers =
+        License :: OSI Approved :: MIT License
+
+        Intended Audience :: Science/Research
+        Intended Audience :: Developers
+
+        Topic :: Software Development
+        Topic :: Scientific/Engineering
+
+        Programming Language :: Python
+        Programming Language :: Python :: 3
+        Programming Language :: Python :: 3 :: Only
+        Programming Language :: Python :: 3.8

--- a/setup.py
+++ b/setup.py
@@ -2,52 +2,7 @@
 
 from setuptools import setup
 
-
-
-
-def get_long_description():
-    ''' returns the content of the README.md file as a string.
-    '''
-    from os import path # pylint: disable=import-outside-toplevel
-
-    this_directory = path.abspath(path.dirname(__file__))
-    with open(path.join(this_directory, 'README.md'), mode='r', encoding='utf-8') as f:
-        long_description = f.read()
-
-    return long_description
-
-
-
 setup(
-    name='fasttrees',
-    packages=['fasttrees'],
-    url='https://github.com/fasttrees/fasttrees',
-    license='MIT License',
-    long_description=get_long_description(),
-    long_description_content_type='text/markdown',
-    classifiers=[
-        'License :: OSI Approved :: MIT License',
-
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Developers',
-
-        'Topic :: Software Development',
-        'Topic :: Scientific/Engineering',
-
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8'
-    ],
-    project_urls={
-        'Documentation': 'https://fasttrees.github.io/fasttrees',
-        'Source': 'https://github.com/fasttrees/fasttrees',
-        'Tracker': 'https://github.com/fasttrees/fasttrees/issues',
-    },
-    python_requires='>=3.8',
-    install_requires=[
-                'numpy<=1.19.5',
-                'pandas<=0.25.3',
-                'scikit-learn<=0.23.2'
-          ]
+    setup_requires=['pbr'],
+    pbr=True
 )


### PR DESCRIPTION
This PR switches packaging to only use ``setup.cfg`` in conjunction with ``Python Build Reasonableness`` (``pbr`` for short)