### PR TITLE
Add pull request closed trigger for documentation workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,15 +4,21 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages
+name: Documentation
 
 on:
   push:
     branches: ["master"]
     paths: ["docs/**"] # only changes in the docs directory triger the workflow
 
+  pull_request:
+    branches: ["master"]
+    types: ["closed"]
+    paths: ["docs/**"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
This PR adds a trigger to the documentation workflow. In particular, it triggers the workflow whenever a pull request is closed and the docs directory has changed.