### PR TITLE
Docs: change name of index in sidebar

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,15 +4,21 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages
+name: Documentation
 
 on:
   push:
     branches: ["master"]
     paths: ["docs/**"] # only changes in the docs directory triger the workflow
 
+  pull_request:
+    branches: ["master"]
+    types: ["closed"]
+    paths: ["docs/**"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "Home | fasttrees"
+title: "Home"
 nav_order: 1
 description: fasttrees is a Python implementation of fast-and-frugal trees, which are a specialisation of decistion trees for binary-classification.
 permalink: /


### PR DESCRIPTION
Change name of index in sidebar from ``Home | fasttrees`` to ``Home``.