### PR TITLE
Add permissions for id-token and contents to pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,6 +70,9 @@ jobs:
 
   # Deployment job
   deploy:
+    permissions:
+        contents: read
+        id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR adds permissions for id-token and contents to pages workflow.

It is an attempt to fix error ``Ensure GITHUB_TOKEN has permission "id-token: write"`` of the deploy job.