### PR TITLE
Add nav_order to examples page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,6 +70,9 @@ jobs:
 
   # Deployment job
   deploy:
+    permissions:
+        contents: read
+        id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: "Introduction by Examples"
+nav_order: 2
 ---
 # Introduction by Examples
 We introduce ``fasttrees`` through self-contained examples.


### PR DESCRIPTION
This PR adds ``nav_order`` to the examples page in the docs.