### PR TITLE
[FIX] Version string for setup-ruby action in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.33.2
+        uses: ruby/setup-ruby@vv1.218.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@vv1.218.0
+        uses: ruby/setup-ruby@v1.218.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
This ``PR`` fixes the wrong version string of the setup-ruby action in the pages worfklow to ``v1.218.0``.