### PR TITLE
[Build] Bump all actions in pylint workflow

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.8.0"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5.4.0
       timeout-minutes: 10
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This ``PR``bumps all actions in the ``pylint``workflow to the newest version. In addition, it also pins all actions to their ``MINOR`` and ``PATCH`` release.