### PR TITLE
[BUILD] Bump or pin runner OS in all workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
         run:
           working-directory: docs

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     # ubuntu-latest doesn't have all the needed Python version. Hence we need to specify Ubuntu 20.04.
     # See issue https://github.com/razorpay/razorpay-python/pull/265
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
         - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   deploy:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
         - uses: actions/checkout@v3


### PR DESCRIPTION
This ``PR`` bumps the runner OS ``Ubuntu`` to version ``24.04`` if the OS is set to an older Ubuntu release, or it pins the version to ``24.04`` if the OS was set to ``ubuntu-latest``, in all workflows.