### PR TITLE
[Build] Bump python version to 3.8.18

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        python-version: ["3.8.0"]
+        python-version: ["3.8.18"]
     steps:
     - uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8.0"]
+        python-version: ["3.8.18"]
 
     steps:
     - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This ``PR`` bumps the python version to ``3.8.18``.

This is done to bump to a newer version of python, which is in preparation of bumping the runner OS to Ubuntu version ``24.04``. See ``PR`` #46.