### PR TITLE
[Build] Rename name keys in three workflows

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python package
+name: Unit Tests
 
 on:
   push:

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -11,7 +11,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload dev-release to TestPyPI
+name: Build and Upload to TestPyPI
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload release to PyPI
+name: Build and Upload release to PyPI
 
 on:
   release:


### PR DESCRIPTION
This ``PR`` renames the `python-publish`, `python-publish-testpypi`, and `python-package` workflows.

This `PR` changes the `name` key in each of the three workflow files to a descriptive name. This is done to increase clarity in what these workflows are actually doing. These changes have an effect on the badges, which are for example display in the `README` file.