### PR TITLE
[Build] Add build job to python-package workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,5 +65,9 @@ jobs:
     needs: unit-tests
 
     steps:
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade build
+
       - name: Build package
         run: python -m build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  unit-tests:
 
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Unit Tests
+name: Unit Tests and Build
 
 on:
   push:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,3 +52,18 @@ jobs:
       uses: codecov/codecov-action@v5.3.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+
+  build:
+    runs-on: ubuntu-24.04
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8.18"]
+
+    needs: unit-tests
+
+    steps:
+      - name: Build package
+        run: python -m build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,6 +65,9 @@ jobs:
     needs: unit-tests
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+
       - name: Install dependencies
         run: |
             python -m pip install --upgrade build


### PR DESCRIPTION
This `PR` adds a `build` job to the `python-package` workflow, and renames the job `build` and the value of key `name` to reflect that change.

This `PR` adds one additional job to the `python-package` workflow which builds the package. This is part of an effort the make this workflow the continuous integration workflow.