### PR TITLE
[BUILD] Set value of key fetch-tags to true for all checkout actions

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
         - uses: actions/checkout@v4.2.2
+          with:
+            fetch-tags: true
 
         - name: Set up Python
           uses: actions/setup-python@v5.4.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
         - uses: actions/checkout@v4.2.2
+          with:
+            fetch-tags: true
 
         - name: Set up Python
           uses: actions/setup-python@v5.4.0


### PR DESCRIPTION
This `PR` set the value of key `fetch-tags` to `true` for all checkout actions, which is needed for `pbr` to automatically pull the version from git history.