### PR TITLE
[BUILD] Set value of key verbose to true for all publish actions

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -49,3 +49,4 @@ jobs:
             user: __token__
             password: ${{ secrets.TEST_PYPI_API_TOKEN }}
             repository_url: https://test.pypi.org/legacy/
+            verbose: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -51,3 +51,4 @@ jobs:
           with:
             user: __token__
             password: ${{ secrets.PYPI_API_TOKEN }}
+            verbose: true


### PR DESCRIPTION
This `PR` set the value of key `verbose` to `true` for all publish actions, which is to make bug fixing easier.