### PR TITLE
[BUILD] Fetch entire git history on checking out repository

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -30,6 +30,7 @@ jobs:
         - uses: actions/checkout@v4.2.2
           with:
             fetch-tags: true
+            fetch-depth: 0
 
         - name: Set up Python
           uses: actions/setup-python@v5.4.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,6 +33,7 @@ jobs:
         - uses: actions/checkout@v4.2.2
           with:
             fetch-tags: true
+            fetch-depth: 0
 
         - name: Set up Python
           uses: actions/setup-python@v5.4.0


### PR DESCRIPTION
This `PR` sets `fetch-depth: 0` for the `checkout` actions in the publishing workflows, which is needed to fetch the [entire git history](https://github.com/marketplace/actions/checkout).

This is needed by `pbr` to auto generate versions.