### PR TITLE
[BUILD] Delete version string in setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@
 
 [metadata]
 name = fasttrees
-version = 1.3.1
 license = MIT
 
 author = Dominic Zijlstra, Stefan Bachhofner


### PR DESCRIPTION
This `PR` deletes the version string in `setup.cfg` as the version is set automatically by `pbr`.