### PR TITLE
[BUILD] Pin all actions in workflow pylint with commit hash

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python-version: ["3.8.18"]
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.4.0

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.4.0
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       timeout-minutes: 10
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
This `PR` pins all actions in the workflow `pylint` with the respective commit hash.

This `PR` pins all actions in the workflow `pylint` using the commit hash. This is done to improve security by following the recommendations of the `OpenSSF` scorecard, and will hence improve the score of the project.