### PR TITLE
[BUILD] Pin all actions in workflow python-package with commit hash

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: ["3.8.18"]
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5.4.0
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5.4.0
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
         pytest --cov .
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5.3.1
+      uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
This `PR` pins all actions in the workflow `python-package` with the respective commit hash.

This `PR` pins all actions in the workflow `python-package` using the commit hash. This is done to improve security by following the recommendations of the `OpenSSF` scorecard, and will hence improve the score of the project.