### PR TITLE
[BUILD] Pin all actions in workflow python-publihs-testpypi with commit hash

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.218.0
+        uses: ruby/setup-ruby@d781c1b4ed31764801bfae177617bb0446f5ef8d #v1.218.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1.218.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3.0.1
         with:
           path: "docs/_site/"
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -88,4 +88,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4.0.5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b #v5.0.0
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -33,7 +33,7 @@ jobs:
             fetch-depth: 0
 
         - name: Set up Python
-          uses: actions/setup-python@v5.4.0
+          uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
           with:
             python-version: '3.12.0'
 

--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-        - uses: actions/checkout@v4.2.2
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
           with:
             fetch-tags: true
             fetch-depth: 0


### PR DESCRIPTION
This `PR` pins all actions in the workflow `python-publihs-testpypi` with the respective commit hash.

This `PR` pins all actions in the workflow `python-publihs-testpypi` using the commit hash. This is done to improve security by following the recommendations of the `OpenSSF` scorecard, and will hence improve the score of the project.