### PR TITLE
[BUILD] Pin all actions in workflow python-publish with commit hash

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
             fetch-depth: 0
 
         - name: Set up Python
-          uses: actions/setup-python@v5.4.0
+          uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
           with:
             python-version: '3.12.0'
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-        - uses: actions/checkout@v4.2.2
+        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
           with:
             fetch-tags: true
             fetch-depth: 0


### PR DESCRIPTION
This `PR` pins all actions in the workflow `python-publish.yml` with the respective commit hash.

This `PR` pins all actions in the workflow `python-publish.yml` using the commit hash. This is done to improve security by following the recommendations of the `OpenSSF` scorecard, and will hence improve the score of the project.