### PR TITLE
[DOC] Add information header containing license and copyright to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019-2024 Stefan Bachhofner <bachhofner.dev@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
 [build-system]
 requires = ["pbr>=6.1.1"]
 build-backend = "pbr.build"


### PR DESCRIPTION
This `PR` adds the information header to the file `pyproject.toml` and resolves one of `REUSE` compliant errors.

The information header contains the license and the copyright.