### PR TITLE
[DOC] Add license section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ X_train_iris, X_test_iris, y_train_iris, y_test_iris = model_selection.train_tes
 fftc = FastFrugalTreeClassifier()
 fftc.fit(X_train_iris, y_train_iris)
 fftc.score(X_test_iris, y_test_iris)
+```
 
 ## Licensing
 Copyright (c) 2019-2024 Dominic Zijlstra, Stefan Bachhofner

--- a/README.md
+++ b/README.md
@@ -48,4 +48,18 @@ X_train_iris, X_test_iris, y_train_iris, y_test_iris = model_selection.train_tes
 fftc = FastFrugalTreeClassifier()
 fftc.fit(X_train_iris, y_train_iris)
 fftc.score(X_test_iris, y_test_iris)
+
+## Licensing
+Copyright (c) 2019-2024 Dominic Zijlstra, Stefan Bachhofner
+
+Licensed under the **MIT (SPDX short identifier: MIT)** (the "License"); you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License by reviewing the file [LICENSE](./LICENSES/MIT.txt) in the repository.
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License.
 ```
+
+This project follows the [REUSE standard for software licensing](https://reuse.software).
+Each file contains copyright and license information, and license texts can be found in the [LICENSES](./LICENSES) folder.
+For more information visit https://reuse.software.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ You may obtain a copy of the License by reviewing the file [LICENSE](./LICENSES/
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the [LICENSE](./LICENSES/Apache-2.0.txt) for the specific language governing permissions and limitations under the License.
-```
 
 This project follows the [REUSE standard for software licensing](https://reuse.software).
 Each file contains copyright and license information, and license texts can be found in the [LICENSES](./LICENSES) folder.


### PR DESCRIPTION
This `PR` adds a license section to the `README`, and hence adds an Open Source best practice.