### PR TITLE
[BUILD] Bump Numpy 1.22.0 and above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-numpy<=1.19.5
+numpy>=1.22.0
 pandas<=0.25.3
 scikit-learn<=0.23.2
 pytest<=7.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 numpy>=1.22.0
 pandas>=1.0.0, <=1.5.3
-scikit-learn<=0.23.2
+scikit-learn>=0.24.0, <=0.24.2
 pytest<=7.4.0
 pytest-cov<=4.1.0
 pbr==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 numpy>=1.22.0
-pandas<=0.25.3
+pandas>=1.0.0, <=1.5.3
 scikit-learn<=0.23.2
 pytest<=7.4.0
 pytest-cov<=4.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.8
 install_requires =
     numpy>=1.22.0,
     pandas>=1.0.0, <=1.5.3
-    scikit-learn<=0.23.2
+    scikit-learn>=0.24.0, <=0.24.2
 
 classifiers =
         License :: OSI Approved :: MIT License

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find: fasttrees
 python_requires = >=3.8
 
 install_requires =
-    numpy<=1.19.5,
+    numpy>=1.22.0,
     pandas<=0.25.3,
     scikit-learn<=0.23.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ python_requires = >=3.8
 
 install_requires =
     numpy>=1.22.0,
-    pandas<=0.25.3,
+    pandas>=1.0.0, <=1.5.3
     scikit-learn<=0.23.2
 
 classifiers =


### PR DESCRIPTION
This `PR` bumps `NumPy` from `<=1.19.5` to `>=1.22.0` to address [`CVE-2021-34141`](https://github.com/fasttrees/fasttrees/security/dependabot/1).

In bumping `NumPy` it is also necessary to bump `pandas` from `pandas<=0.25.3` to `pandas>=1.0.0, <=1.5.3`, and `scikit-learn` from `scikit-learn<=0.23.2` to `scikit-learn>=0.24.0, <=0.24.2`.