### PR TITLE
[BUILD] Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global code owners for the repository.
+* @MacOS


### PR DESCRIPTION
This ``PR`` adds the ``CODEOWNERS`` file to the repository, and has an effect on whom must review a `PR`, and in effect it also influences the `OpenSSF` score.